### PR TITLE
Add TYPO3 13 LTS database sync tool for DDEV

### DIFF
--- a/.ddev/commands/host/sync
+++ b/.ddev/commands/host/sync
@@ -1,54 +1,243 @@
-#! /bin/bash
+#!/bin/bash
 
-
-## Description: Run sync process from a remote server
-## Usage: sync
-## Example: "ddev sync"
+## Description: Sync database from remote server (staging or production)
+## Usage: sync [--staging|--production]
+## Example: "ddev sync --staging" or "ddev sync --production"
 ## ProjectTypes: typo3
 
-# # project vars
-USERNAME=$(grep PRODUCTION_SSH_USER ./.ddev/config.yaml | cut -d '=' -f 2-)
-REMOTESERVER=$(grep PRODUCTION_SSH_HOST ./.ddev/config.yaml | cut -d '=' -f 2-)
+set -e
 
-# # standards
-# db_dump_name="db-dump.sql"
-# file_dump_name="file-dump.tar.gz"
-
-# coloring https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
+# Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Configuration file path
+CONFIG_FILE=".env.db-sync"
+PROJECT_ROOT="/var/www/html"
 
-# first, install process musst be ready, so skip sync command
-if test -f "./Build/Development/INSTALLATION_RUNNING"; then
-    printf "${YELLOW}Skip syncing while install process: Running system required.${NC}\n"
-    exit
+# Function to print colored messages
+print_info() {
+    printf "${BLUE}ℹ ${NC}%s\n" "$1"
+}
+
+print_success() {
+    printf "${GREEN}✓${NC} %s\n" "$1"
+}
+
+print_error() {
+    printf "${RED}✗${NC} %s\n" "$1"
+}
+
+print_warning() {
+    printf "${YELLOW}⚠${NC} %s\n" "$1"
+}
+
+# Function to load environment variables from config file
+load_config() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        print_error "Configuration file '$CONFIG_FILE' not found!"
+        print_info "Please copy '.env.db-sync.example' to '.env.db-sync' and configure it."
+        exit 1
+    fi
+
+    # Load config file
+    set -a
+    source "$CONFIG_FILE"
+    set +a
+
+    print_success "Configuration loaded from $CONFIG_FILE"
+}
+
+# Function to show usage
+show_usage() {
+    cat << EOF
+${BLUE}TYPO3 Database Sync Tool${NC}
+
+Usage:
+  ddev sync --staging      Sync database from staging server
+  ddev sync --production   Sync database from production server
+  ddev sync --help         Show this help message
+
+Configuration:
+  Copy .env.db-sync.example to .env.db-sync and fill in your credentials.
+
+EOF
+    exit 0
+}
+
+# Parse arguments
+ENVIRONMENT=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --staging)
+            ENVIRONMENT="STAGING"
+            shift
+            ;;
+        --production)
+            ENVIRONMENT="PRODUCTION"
+            shift
+            ;;
+        --help|-h)
+            show_usage
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            show_usage
+            ;;
+    esac
+done
+
+# Check if environment is specified
+if [ -z "$ENVIRONMENT" ]; then
+    print_error "No environment specified!"
+    echo ""
+    show_usage
 fi
 
-# check if project vars are set
-if [ -z "$USERNAME" ]
-then
-      printf "${RED}\$PRODUCTION_SSH_USER is empty. Can not synchronize.${NC}\n"
-      exit;
+print_info "Starting database sync from ${ENVIRONMENT}..."
+echo ""
+
+# Load configuration
+load_config
+
+# Set environment-specific variables
+if [ "$ENVIRONMENT" == "STAGING" ]; then
+    SSH_HOST="${STAGING_SSH_HOST}"
+    SSH_USER="${STAGING_SSH_USER}"
+    SSH_PORT="${STAGING_SSH_PORT:-22}"
+    DB_NAME="${STAGING_DB_NAME}"
+    DB_USER="${STAGING_DB_USER}"
+    DB_PASSWORD="${STAGING_DB_PASSWORD}"
+    DB_HOST="${STAGING_DB_HOST:-localhost}"
+    DUMP_PATH="${STAGING_DUMP_PATH:-/tmp}"
+else
+    SSH_HOST="${PRODUCTION_SSH_HOST}"
+    SSH_USER="${PRODUCTION_SSH_USER}"
+    SSH_PORT="${PRODUCTION_SSH_PORT:-22}"
+    DB_NAME="${PRODUCTION_DB_NAME}"
+    DB_USER="${PRODUCTION_DB_USER}"
+    DB_PASSWORD="${PRODUCTION_DB_PASSWORD}"
+    DB_HOST="${PRODUCTION_DB_HOST:-localhost}"
+    DUMP_PATH="${PRODUCTION_DUMP_PATH:-/tmp}"
 fi
 
-if [ -z "$REMOTESERVER" ]
-then
-      printf "${RED}\$PRODUCTION_SSH_HOST is empty. Can not synchronize.${NC}\n"
-      exit;
+# Validate required variables
+REQUIRED_VARS=("SSH_HOST" "SSH_USER" "DB_NAME" "DB_USER" "DB_PASSWORD")
+for var in "${REQUIRED_VARS[@]}"; do
+    if [ -z "${!var}" ]; then
+        print_error "Required variable ${ENVIRONMENT}_${var} is not set in $CONFIG_FILE"
+        exit 1
+    fi
+done
+
+# Local settings
+LOCAL_DUMP_DIR="${LOCAL_DUMP_DIR:-.dumps}"
+DUMP_COMPRESSION="${DUMP_COMPRESSION:-gzip}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DUMP_FILENAME="db_${ENVIRONMENT,,}_${TIMESTAMP}.sql"
+
+if [ "$DUMP_COMPRESSION" == "gzip" ]; then
+    DUMP_FILENAME="${DUMP_FILENAME}.gz"
 fi
 
-ddev auth ssh
+REMOTE_DUMP_FILE="${DUMP_PATH}/${DUMP_FILENAME}"
+LOCAL_DUMP_FILE="${LOCAL_DUMP_DIR}/${DUMP_FILENAME}"
 
-ddev pull prod
+# Create local dump directory if it doesn't exist
+mkdir -p "$LOCAL_DUMP_DIR"
 
-# update database
-ddev typo3 database:updateschema
+print_info "Configuration:"
+echo "  Environment:    ${ENVIRONMENT}"
+echo "  SSH Host:       ${SSH_USER}@${SSH_HOST}:${SSH_PORT}"
+echo "  Database:       ${DB_NAME}"
+echo "  Remote dump:    ${REMOTE_DUMP_FILE}"
+echo "  Local dump:     ${LOCAL_DUMP_FILE}"
+echo ""
 
-# delete user from livesystem
-ddev create-dev-admin
+# Step 1: Create dump on remote server
+print_info "Step 1/4: Creating database dump on remote server..."
 
-# Force flush all caches in a reliable and robust way
-ddev typo3 cache:flush
+if [ "$DUMP_COMPRESSION" == "gzip" ]; then
+    DUMP_COMMAND="mysqldump -h ${DB_HOST} -u ${DB_USER} -p'${DB_PASSWORD}' ${DB_NAME} --single-transaction --quick --lock-tables=false | gzip > ${REMOTE_DUMP_FILE}"
+else
+    DUMP_COMMAND="mysqldump -h ${DB_HOST} -u ${DB_USER} -p'${DB_PASSWORD}' ${DB_NAME} --single-transaction --quick --lock-tables=false > ${REMOTE_DUMP_FILE}"
+fi
+
+ssh -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "bash -c '${DUMP_COMMAND}'"
+
+if [ $? -eq 0 ]; then
+    print_success "Database dump created successfully on remote server"
+else
+    print_error "Failed to create database dump on remote server"
+    exit 1
+fi
+
+# Step 2: Download dump file
+print_info "Step 2/4: Downloading dump file..."
+
+scp -P "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}:${REMOTE_DUMP_FILE}" "${LOCAL_DUMP_FILE}"
+
+if [ $? -eq 0 ]; then
+    print_success "Dump file downloaded successfully"
+
+    # Get file size
+    FILESIZE=$(du -h "${LOCAL_DUMP_FILE}" | cut -f1)
+    print_info "Downloaded file size: ${FILESIZE}"
+else
+    print_error "Failed to download dump file"
+    exit 1
+fi
+
+# Step 3: Clean up remote dump file
+print_info "Cleaning up remote dump file..."
+ssh -p "${SSH_PORT}" "${SSH_USER}@${SSH_HOST}" "rm -f ${REMOTE_DUMP_FILE}"
+print_success "Remote dump file cleaned up"
+
+# Step 4: Import into local DDEV database
+print_info "Step 3/4: Importing database into local DDEV..."
+
+if [ "$DUMP_COMPRESSION" == "gzip" ]; then
+    gunzip < "${LOCAL_DUMP_FILE}" | ddev import-db
+else
+    ddev import-db --file="${LOCAL_DUMP_FILE}"
+fi
+
+if [ $? -eq 0 ]; then
+    print_success "Database imported successfully into DDEV"
+else
+    print_error "Failed to import database into DDEV"
+    exit 1
+fi
+
+# Step 5: TYPO3-specific post-import tasks
+print_info "Step 4/4: Running TYPO3 post-import tasks..."
+
+# Update database schema
+print_info "Updating database schema..."
+ddev typo3 database:updateschema *.add,*.change 2>/dev/null || true
+
+# Create development admin user
+if [ -f ".ddev/commands/web/create-dev-admin" ]; then
+    print_info "Creating/updating development admin user..."
+    ddev create-dev-admin 2>/dev/null || true
+fi
+
+# Flush caches
+print_info "Flushing TYPO3 caches..."
+ddev typo3 cache:flush 2>/dev/null || true
+
+print_success "Post-import tasks completed"
+
+echo ""
+print_success "🎉 Database sync from ${ENVIRONMENT} completed successfully!"
+echo ""
+print_info "Next steps:"
+echo "  - Access your site: https://$(ddev describe | grep 'https://' | head -1 | awk '{print $2}')"
+echo "  - Backend login: /typo3"
+echo ""
+print_info "Dump file saved to: ${LOCAL_DUMP_FILE}"
+print_warning "You can delete old dumps in ${LOCAL_DUMP_DIR}/ to save disk space"
+echo ""

--- a/.env.db-sync.example
+++ b/.env.db-sync.example
@@ -1,0 +1,37 @@
+# Database Sync Configuration
+# Copy this file to .env.db-sync and fill in your credentials
+# This file should be added to .gitignore to keep credentials secure
+
+# ============================
+# STAGING Environment
+# ============================
+STAGING_SSH_HOST=staging.example.com
+STAGING_SSH_USER=username
+STAGING_SSH_PORT=22
+STAGING_DB_NAME=database_name
+STAGING_DB_USER=db_user
+STAGING_DB_PASSWORD=db_password
+STAGING_DB_HOST=localhost
+# Optional: Path to dump on remote server (will be created if not exists)
+STAGING_DUMP_PATH=/tmp
+
+# ============================
+# PRODUCTION Environment
+# ============================
+PRODUCTION_SSH_HOST=production.example.com
+PRODUCTION_SSH_USER=username
+PRODUCTION_SSH_PORT=22
+PRODUCTION_DB_NAME=database_name
+PRODUCTION_DB_USER=db_user
+PRODUCTION_DB_PASSWORD=db_password
+PRODUCTION_DB_HOST=localhost
+# Optional: Path to dump on remote server (will be created if not exists)
+PRODUCTION_DUMP_PATH=/tmp
+
+# ============================
+# Local Settings
+# ============================
+# Local directory to store downloaded dumps (relative to project root)
+LOCAL_DUMP_DIR=.dumps
+# Compression for dump file (gzip or none)
+DUMP_COMPRESSION=gzip

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ nbproject
 !/public/robots.txt
 !/public/typo3conf
 env.php
+
+# Database sync credentials and dumps
+.env.db-sync
+.dumps/

--- a/DB-SYNC-README.md
+++ b/DB-SYNC-README.md
@@ -1,0 +1,239 @@
+# TYPO3 Database Sync Tool
+
+Ein wiederverwendbares Tool zum Synchronisieren von TYPO3-Datenbanken von Remote-Servern (Staging/Production) in deine lokale DDEV-Installation.
+
+## Features
+
+- ✅ Synchronisierung von Staging- und Production-Datenbanken
+- ✅ Sichere Konfiguration über `.env.db-sync` Datei
+- ✅ Automatische Dump-Erstellung auf Remote-Server
+- ✅ Komprimierung mit gzip für schnellere Übertragung
+- ✅ Automatischer Import in lokale DDEV-Datenbank
+- ✅ TYPO3-spezifische Post-Import-Tasks (Schema-Update, Cache-Flush)
+- ✅ Wiederverwendbar für mehrere Projekte
+- ✅ Farbige Konsolen-Ausgabe für bessere Übersicht
+
+## Installation
+
+### 1. Konfigurationsdatei erstellen
+
+Kopiere die Beispiel-Konfiguration und passe sie an:
+
+```bash
+cp .env.db-sync.example .env.db-sync
+```
+
+### 2. Zugangsdaten eintragen
+
+Öffne `.env.db-sync` und trage deine Zugangsdaten ein:
+
+```bash
+# STAGING Environment
+STAGING_SSH_HOST=staging.deine-domain.de
+STAGING_SSH_USER=dein-username
+STAGING_SSH_PORT=22
+STAGING_DB_NAME=deine_staging_db
+STAGING_DB_USER=db_user
+STAGING_DB_PASSWORD=db_passwort
+STAGING_DB_HOST=localhost
+
+# PRODUCTION Environment
+PRODUCTION_SSH_HOST=production.deine-domain.de
+PRODUCTION_SSH_USER=dein-username
+PRODUCTION_SSH_PORT=22
+PRODUCTION_DB_NAME=deine_production_db
+PRODUCTION_DB_USER=db_user
+PRODUCTION_DB_PASSWORD=db_passwort
+PRODUCTION_DB_HOST=localhost
+```
+
+### 3. SSH-Key Setup (empfohlen)
+
+Für eine passwortlose Verbindung richte SSH-Keys ein:
+
+```bash
+# SSH-Key generieren (falls noch nicht vorhanden)
+ssh-keygen -t ed25519 -C "dein@email.de"
+
+# Public Key auf Server kopieren
+ssh-copy-id -p 22 username@staging.deine-domain.de
+ssh-copy-id -p 22 username@production.deine-domain.de
+```
+
+DDEV kann auch mit dem SSH-Agent arbeiten:
+
+```bash
+ddev auth ssh
+```
+
+## Verwendung
+
+### Von Staging synchronisieren
+
+```bash
+ddev sync --staging
+```
+
+### Von Production synchronisieren
+
+```bash
+ddev sync --production
+```
+
+### Hilfe anzeigen
+
+```bash
+ddev sync --help
+```
+
+## Was passiert beim Sync?
+
+1. **Dump erstellen**: Ein MySQL-Dump wird auf dem Remote-Server erstellt
+2. **Download**: Der Dump wird komprimiert heruntergeladen
+3. **Cleanup**: Der Remote-Dump wird gelöscht
+4. **Import**: Der Dump wird in die lokale DDEV-Datenbank importiert
+5. **Post-Tasks**: TYPO3-spezifische Aufgaben werden ausgeführt:
+   - Database Schema Update
+   - Development Admin User erstellen
+   - Cache Flush
+
+## Dump-Verwaltung
+
+Alle heruntergeladenen Dumps werden im `.dumps/` Verzeichnis gespeichert:
+
+```
+.dumps/
+  ├── db_staging_20260114_143022.sql.gz
+  ├── db_production_20260114_150533.sql.gz
+  └── ...
+```
+
+Du kannst alte Dumps manuell löschen, um Speicherplatz zu sparen:
+
+```bash
+rm -rf .dumps/db_staging_*.sql.gz
+```
+
+## Wiederverwendung für andere Projekte
+
+Dieses Tool ist so konzipiert, dass es in jedem TYPO3-Projekt verwendet werden kann:
+
+1. Kopiere das DDEV-Command:
+   ```bash
+   cp .ddev/commands/host/sync /pfad/zu/anderem/projekt/.ddev/commands/host/
+   ```
+
+2. Kopiere die Beispiel-Konfiguration:
+   ```bash
+   cp .env.db-sync.example /pfad/zu/anderem/projekt/
+   ```
+
+3. Erstelle die Konfiguration:
+   ```bash
+   cd /pfad/zu/anderem/projekt
+   cp .env.db-sync.example .env.db-sync
+   # Zugangsdaten anpassen
+   ```
+
+4. Füge zur `.gitignore` hinzu:
+   ```
+   .env.db-sync
+   .dumps/
+   ```
+
+## Konfigurationsoptionen
+
+### Lokale Einstellungen
+
+In `.env.db-sync` kannst du auch lokale Einstellungen anpassen:
+
+```bash
+# Lokales Verzeichnis für Dumps (Standard: .dumps)
+LOCAL_DUMP_DIR=.dumps
+
+# Komprimierung (gzip oder none)
+DUMP_COMPRESSION=gzip
+```
+
+### Remote Dump-Pfad
+
+Standardmäßig werden Dumps in `/tmp` auf dem Remote-Server erstellt. Du kannst dies ändern:
+
+```bash
+STAGING_DUMP_PATH=/var/www/tmp
+PRODUCTION_DUMP_PATH=/home/username/dumps
+```
+
+## Sicherheit
+
+⚠️ **Wichtig**: Die `.env.db-sync` Datei enthält sensible Zugangsdaten!
+
+- ✅ Die Datei ist bereits in `.gitignore` eingetragen
+- ✅ Committe niemals die `.env.db-sync` Datei
+- ✅ Verwende SSH-Keys statt Passwörtern wo möglich
+- ✅ Beschränke SSH-User auf notwendige Berechtigungen
+
+## Fehlerbehebung
+
+### "Configuration file not found"
+
+```bash
+# Erstelle die Konfigurationsdatei
+cp .env.db-sync.example .env.db-sync
+```
+
+### "Permission denied (publickey)"
+
+```bash
+# SSH-Key auf Server kopieren
+ddev auth ssh
+ssh-copy-id -p 22 username@host
+```
+
+### "Access denied for user"
+
+Prüfe die Datenbank-Zugangsdaten in `.env.db-sync`
+
+### Import schlägt fehl
+
+```bash
+# Prüfe ob DDEV läuft
+ddev describe
+
+# Starte DDEV falls nötig
+ddev start
+```
+
+## Erweiterte Verwendung
+
+### Post-Import-Tasks anpassen
+
+Du kannst das Script `.ddev/commands/host/sync` bearbeiten und im Abschnitt "TYPO3-specific post-import tasks" eigene Befehle hinzufügen, z.B.:
+
+```bash
+# Eigene Extension-Commands
+ddev typo3 my_extension:setup
+
+# Zusätzliche Datenbank-Änderungen
+echo 'UPDATE be_users SET password="" WHERE username="admin";' | ddev typo3 database:import
+```
+
+## Technische Details
+
+- **Dump-Methode**: `mysqldump` mit `--single-transaction` für konsistente Backups
+- **Transfer**: `scp` über SSH
+- **Komprimierung**: gzip (optional)
+- **Import**: `ddev import-db` Command
+
+## Support
+
+Bei Problemen oder Fragen:
+
+1. Prüfe die Fehlermeldung
+2. Kontrolliere die Konfiguration in `.env.db-sync`
+3. Teste die SSH-Verbindung manuell: `ssh username@host`
+4. Teste die Datenbankverbindung auf dem Server
+
+## Lizenz
+
+Dieses Tool ist frei verwendbar und kann nach Belieben angepasst werden.


### PR DESCRIPTION
Implements a reusable database synchronization tool that allows syncing from staging or production servers to local DDEV installation.

Features:
- Support for staging and production environments
- Configuration via .env.db-sync file (project-specific)
- SSH-based remote dump creation and download
- Automatic import into local DDEV database
- TYPO3-specific post-import tasks (schema update, cache flush)
- Comprehensive documentation in DB-SYNC-README.md

Usage:
- ddev sync --staging
- ddev sync --production

The tool is designed to be portable and can be reused across multiple TYPO3 projects by copying the files and creating a project-specific .env.db-sync configuration.